### PR TITLE
automatic old reservations deletion

### DIFF
--- a/app/src/main/java/com/example/parkingsystemjava/activities/ReservationActivity.java
+++ b/app/src/main/java/com/example/parkingsystemjava/activities/ReservationActivity.java
@@ -38,6 +38,7 @@ public class ReservationActivity extends AppCompatActivity implements ListenerDa
     }
 
     private void makeReservation() {
+        presenter.deleteOldReservations();
         presenter.validateAndSaveReservation(
                 binding.editTextReservationActivityEntry.getText().toString(),
                 binding.editTextReservationActivityExit.getText().toString(),

--- a/app/src/main/java/com/example/parkingsystemjava/database/ReservationDatabase.java
+++ b/app/src/main/java/com/example/parkingsystemjava/database/ReservationDatabase.java
@@ -1,7 +1,9 @@
 package com.example.parkingsystemjava.database;
 
 import com.example.parkingsystemjava.entity.Reservation;
+import com.example.parkingsystemjava.utils.Constants;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 
@@ -37,5 +39,21 @@ public class ReservationDatabase {
 
     public void setParkingLots(String parkingLots) {
         this.parkingLots = Integer.parseInt(parkingLots);
+    }
+
+    public void deleteOldReservations() {
+        Calendar today = Calendar.getInstance();
+        int parkingLots = Integer.parseInt(this.getParkingLots());
+        List<Reservation> reservations = new ArrayList<>();
+        for (int indexParkingLots = Constants.ZERO; indexParkingLots <= parkingLots; indexParkingLots++) {
+            if (this.getReservations(indexParkingLots) != null) {
+                reservations.addAll(this.getReservations(indexParkingLots));
+                for (int indexReservations = Constants.ZERO; indexReservations < reservations.size(); indexReservations++) {
+                    if (reservations.get(indexReservations).getExitDate().before(today)) {
+                        reservations.remove(reservations.get(indexReservations));
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/parkingsystemjava/mvp/contract/ParkingReservationContract.java
+++ b/app/src/main/java/com/example/parkingsystemjava/mvp/contract/ParkingReservationContract.java
@@ -14,6 +14,7 @@ public interface ParkingReservationContract {
         void setExitDate(Calendar exitDate);
         boolean validateReservation(Reservation reservation, int parkingLot);
         void validateAndSaveReservation(String entryDate, String exitDate, String keyCode, String parkingLot);
+        void deleteOldReservations();
     }
 
     interface ParkingReservationView {
@@ -27,10 +28,12 @@ public interface ParkingReservationContract {
         void showKeyErrorMessage();
         void showParkingLotErrorMessage();
         void closeScreen();
+        void showOldReservationDeletionMessage();
     }
 
     interface ParkingReservationModel {
         void addReservation(Reservation reservation, int parkingLot);
         ReservationErrorCodes validateReservation(Reservation reservation, int parkingLot);
+        void deleteOldReservations();
     }
 }

--- a/app/src/main/java/com/example/parkingsystemjava/mvp/model/ParkingModel.java
+++ b/app/src/main/java/com/example/parkingsystemjava/mvp/model/ParkingModel.java
@@ -1,12 +1,7 @@
 package com.example.parkingsystemjava.mvp.model;
 
 import com.example.parkingsystemjava.database.ReservationDatabase;
-import com.example.parkingsystemjava.entity.Reservation;
 import com.example.parkingsystemjava.mvp.contract.ParkingContract;
-import com.example.parkingsystemjava.utils.Constants;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
 
 public class ParkingModel implements ParkingContract.MainActivityModel {
     private ReservationDatabase database;
@@ -27,18 +22,6 @@ public class ParkingModel implements ParkingContract.MainActivityModel {
 
     @Override
     public void deleteOldReservations() {
-        Calendar today = Calendar.getInstance();
-        int parkingLots = Integer.parseInt(database.getParkingLots());
-        List<Reservation> reservations = new ArrayList<>();
-        for (int indexParkingLots = Constants.ZERO; indexParkingLots <= parkingLots; indexParkingLots++) {
-            if (database.getReservations(indexParkingLots) != null) {
-                reservations.addAll(database.getReservations(indexParkingLots));
-                for (int indexReservations = Constants.ZERO; indexReservations < reservations.size(); indexReservations++) {
-                    if (reservations.get(indexReservations).getExitDate().before(today)) {
-                        reservations.remove(reservations.get(indexReservations));
-                    }
-                }
-            }
-        }
+        database.deleteOldReservations();
     }
 }

--- a/app/src/main/java/com/example/parkingsystemjava/mvp/model/ParkingReservationModel.java
+++ b/app/src/main/java/com/example/parkingsystemjava/mvp/model/ParkingReservationModel.java
@@ -28,6 +28,11 @@ public class ParkingReservationModel implements ParkingReservationContract.Parki
         else return ReservationErrorCodes.OK;
     }
 
+    @Override
+    public void deleteOldReservations() {
+        database.deleteOldReservations();
+    }
+
     private boolean comprobateOverlapping(Reservation reservation, int parkingLot) {
         List<Reservation> reservations = database.getReservations(parkingLot);
         Calendar reservationEntryDate = reservation.getEntryDate();

--- a/app/src/main/java/com/example/parkingsystemjava/mvp/presenter/ParkingReservationPresenter.java
+++ b/app/src/main/java/com/example/parkingsystemjava/mvp/presenter/ParkingReservationPresenter.java
@@ -80,4 +80,10 @@ public class ParkingReservationPresenter implements ParkingReservationContract.P
             view.closeScreen();
         }
     }
+
+    @Override
+    public void deleteOldReservations() {
+        model.deleteOldReservations();
+        view.showOldReservationDeletionMessage();
+    }
 }

--- a/app/src/main/java/com/example/parkingsystemjava/mvp/view/ParkingReservationView.java
+++ b/app/src/main/java/com/example/parkingsystemjava/mvp/view/ParkingReservationView.java
@@ -82,4 +82,9 @@ public class ParkingReservationView extends ActivityView implements ParkingReser
         if (activity != null)
             activity.finish();
     }
+
+    @Override
+    public void showOldReservationDeletionMessage() {
+        showMessage(R.string.reservation_activity_delete_old_reservations);
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="reservation_activity_text_overlapping_error_message">This reservation is overlapping with another one!</string>
     <string name="delete_out_dated_reservations">Delete out-dated reservations</string>
     <string name="main_activity_toast_delete_old_reservations">Old reservations deleted!</string>
+    <string name="reservation_activity_delete_old_reservations">Old reservations deleted!</string>
 </resources>


### PR DESCRIPTION
Automatic deletion of Old reservations
-moved deletion method to database
-added methods to ParkingReservationModel, ParkingReservationPresenter.
 Device: Pixel 3a

set first reservation:
<img width="452" alt="Capture1" src="https://user-images.githubusercontent.com/84336381/125477881-77081660-ab7e-4ef8-b638-f2ca419fd33d.PNG">
set second reservation on an old date:
<img width="460" alt="Capture2" src="https://user-images.githubusercontent.com/84336381/125478044-072242f1-cc88-47ee-be79-4c72d51f757a.PNG">
set third reservation, this show only 2 reservations because the last one was deleted before adding this one:
<img width="459" alt="Capture3" src="https://user-images.githubusercontent.com/84336381/125478254-714c9ccc-dd74-41e7-bdb3-3276fe9037ec.PNG">
show Toast about the deletion:
![image](https://user-images.githubusercontent.com/84336381/125480002-ff6a1b35-67f0-4558-a246-bd52a5d76029.png)
